### PR TITLE
Moved imageView property from private (in *.m) to public (in *.h) to …

### DIFF
--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, assign) CGSize cropSize;
 @property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, strong) UIBezierPath *cropMaskPath;
 @property (nonatomic, strong) UIView *cropMaskView;
 @property (nonatomic, readonly) UIView *borderView;

--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -12,8 +12,8 @@
 
 @property (nonatomic, assign) CGSize cropSize;
 @property (nonatomic, strong) UIImage *image;
-@property (nonatomic, strong) UIImageView *imageView;
-@property (nonatomic, strong) UIScrollView *scrollView;
+@property (readonly, nonatomic, strong) UIImageView *imageView;
+@property (readonly, nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIBezierPath *cropMaskPath;
 @property (nonatomic, strong) UIView *cropMaskView;
 @property (nonatomic, readonly) UIView *borderView;

--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -13,6 +13,7 @@
 @property (nonatomic, assign) CGSize cropSize;
 @property (nonatomic, strong) UIImage *image;
 @property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIBezierPath *cropMaskPath;
 @property (nonatomic, strong) UIView *cropMaskView;
 @property (nonatomic, readonly) UIView *borderView;

--- a/Pod/Classes/BABCropperView.m
+++ b/Pod/Classes/BABCropperView.m
@@ -174,14 +174,14 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
     
     self.backgroundColor = [UIColor blackColor];
     
-    self.scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+    _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
     self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.scrollView.showsHorizontalScrollIndicator = NO;
     self.scrollView.showsVerticalScrollIndicator = NO;
     self.scrollView.delegate = self;
     [self addSubview:self.scrollView];
     
-    self.imageView = [[UIImageView alloc] init];
+    _imageView = [[UIImageView alloc] init];
     [self.scrollView addSubview:self.imageView];
     
     self.cropMaskView = [[UIView alloc] initWithFrame:self.bounds];

--- a/Pod/Classes/BABCropperView.m
+++ b/Pod/Classes/BABCropperView.m
@@ -132,7 +132,6 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
 
 @interface BABCropperView()<UIScrollViewDelegate>
 
-@property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIView *borderView;
 
 @property (nonatomic, assign) CGSize scaledCropSize;

--- a/Pod/Classes/BABCropperView.m
+++ b/Pod/Classes/BABCropperView.m
@@ -133,7 +133,6 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
 @interface BABCropperView()<UIScrollViewDelegate>
 
 @property (nonatomic, strong) UIScrollView *scrollView;
-@property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, strong) UIView *borderView;
 
 @property (nonatomic, assign) CGSize scaledCropSize;


### PR DESCRIPTION
…enable use of category, such as FaceAwareFill.

Also set the properties as readonly to maintain integrity of the internal implementation (which could break if users set these properties)