### PR TITLE
more cropping behavior control

### DIFF
--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -23,6 +23,7 @@
 @property (nonatomic, assign) BOOL leavesUnfilledRegionsTransparent; // defaults to NO
 @property (nonatomic, assign) BOOL allowsNegativeSpaceInCroppedImage; //defaults to NO
 @property (nonatomic, assign) BOOL startZoomedToFill; // defaults to NO
+@property (nonatomic, assign) CGFloat maximumZoomScale; // defaults to 4
 
 - (void)renderCroppedImage:(void (^)(UIImage *croppedImage, CGRect cropRect))completionBlock;
 

--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -28,16 +28,16 @@
  Default 0.0 keeps legacy and scrollView.maximumZoomScale is set to BABCropperViewMaximumZoomScale = 4.0
 
  Positive value defines what image upscale (resulting to pixelation) is allowed.
- E.g. value of 1 ensures that the cropped image will be 1:1 comapred to the source image
+ E.g. value of 1 ensures that the cropped image will be at worst 1:1 comapred to the source image
 */
 @property (nonatomic, assign) CGFloat maximumImageUpscale; // defaults to 0
 
 /**
  Defines maximum allowed size of the cropped image compared to wanted cropSize.
 
- Default value of 1.0 ensures any cropped image will be exactly equal to croppedSize.
+ Default value of 1.0 ensures any cropped image will be exactly equal to cropSize.
 
- Value of 2.0 allows the croped image to be maximum 2x bigger then requested cropSize.
+ E.g value of 2.0 allows the cropped image to be maximum 2x bigger then requested cropSize.
 
  The cropped size can be expressed like: min(sourceSize, scale(cropSize, maximumImageOversize))
 */

--- a/Pod/Classes/BABCropperView.h
+++ b/Pod/Classes/BABCropperView.h
@@ -23,7 +23,25 @@
 @property (nonatomic, assign) BOOL leavesUnfilledRegionsTransparent; // defaults to NO
 @property (nonatomic, assign) BOOL allowsNegativeSpaceInCroppedImage; //defaults to NO
 @property (nonatomic, assign) BOOL startZoomedToFill; // defaults to NO
-@property (nonatomic, assign) CGFloat maximumZoomScale; // defaults to 4
+
+/**
+ Default 0.0 keeps legacy and scrollView.maximumZoomScale is set to BABCropperViewMaximumZoomScale = 4.0
+
+ Positive value defines what image upscale (resulting to pixelation) is allowed.
+ E.g. value of 1 ensures that the cropped image will be 1:1 comapred to the source image
+*/
+@property (nonatomic, assign) CGFloat maximumImageUpscale; // defaults to 0
+
+/**
+ Defines maximum allowed size of the cropped image compared to wanted cropSize.
+
+ Default value of 1.0 ensures any cropped image will be exactly equal to croppedSize.
+
+ Value of 2.0 allows the croped image to be maximum 2x bigger then requested cropSize.
+
+ The cropped size can be expressed like: min(sourceSize, scale(cropSize, maximumImageOversize))
+*/
+@property (nonatomic, assign) CGFloat maximumCropOversize; // defaults to 1
 
 - (void)renderCroppedImage:(void (^)(UIImage *croppedImage, CGRect cropRect))completionBlock;
 

--- a/Pod/Classes/BABCropperView.m
+++ b/Pod/Classes/BABCropperView.m
@@ -321,7 +321,6 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
             }
         }
         
-        //self.scrollView.maximumZoomScale = BABCropperViewMaximumZoomScale;
         self.scrollView.maximumZoomScale = self.maximumZoomScale;
         self.scrollView.zoomScale = self.startZoomedToFill ? startingZoomScale : self.scrollView.minimumZoomScale;
     }

--- a/Pod/Classes/BABCropperView.m
+++ b/Pod/Classes/BABCropperView.m
@@ -171,6 +171,7 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
     self.operationQueue = [[NSOperationQueue alloc] init];
     self.cropDisplayScale = 1.0f;
     self.cropDisplayOffset = UIOffsetZero;
+    self.maximumZoomScale = BABCropperViewMaximumZoomScale;
     
     self.backgroundColor = [UIColor blackColor];
     
@@ -226,6 +227,13 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
     
     _cropsImageToCircle = cropsImageToCircle;
     
+    [self setNeedsLayout];
+}
+
+- (void) setMaximumZoomScale:(CGFloat)maximumZoomScale {
+
+    _maximumZoomScale = maximumZoomScale;
+
     [self setNeedsLayout];
 }
 
@@ -313,7 +321,8 @@ static UIImage* BABCropperViewCroppedAndScaledImageWithCropRect(UIImage *image, 
             }
         }
         
-        self.scrollView.maximumZoomScale = BABCropperViewMaximumZoomScale;
+        //self.scrollView.maximumZoomScale = BABCropperViewMaximumZoomScale;
+        self.scrollView.maximumZoomScale = self.maximumZoomScale;
         self.scrollView.zoomScale = self.startZoomedToFill ? startingZoomScale : self.scrollView.minimumZoomScale;
     }
 }


### PR DESCRIPTION
This fixes #24 and more. Take it as a proposal how to extend this handy tool.

Motivation: for you service avatar you need an image of size 200x200 to 1000x1000 pixels. Currently it's only possible to set fixed cropped size - what will result to discarding some pixels if the selected image source rect is bigger then 200px.

The `maximumCropOversize` defines what is allowed ratio between requested cropSize and maximal cropped size if the source rectangle provided enough pixels. If we specify `cropSize = (200, 200)` and   `maximumCropOversize = 5.0` the cropped size will

a) never be less then 200x200 (imageRect <= 200x200)
b) wil be in range 200..<1000 (imageRect > 200x200 AND imageRect <=1000x1000)
c) will never exceed 1000x1000 (imageRect > 1000x1000)

In addition I added `maximumImageUpscale` defining amount the image can be stretched to fill wanted `cropSize`. Default is 0 - what will result to legacy behavior when the maxZoomScale for the scroll view is set to 4.0.

Non-zero value defines how much the image can be zoomed before cropping.

a) `maximumImageUpscale = 1` image can be zoomed so that imageRect will never be smaller then `cropSize`
b) `maximumImageUpscale = 2` image can be zoomed up to a half size of wanted `cropSize`
c) `maximumImageUpscale < 1.0 is not tested and possibly a bit undefined (and does not make much sense)

I hope you will find these changes useful. At least I tried to keep legacy behavior in all cases.